### PR TITLE
Used absolute path token to resolve file path

### DIFF
--- a/system_tests/responder.bat
+++ b/system_tests/responder.bat
@@ -1,1 +1,1 @@
-start "The SNMP Emulator" ..\..\..\..\..\Python3\Scripts\snmpsim-command-responder --agent-udpv4-endpoint=127.0.0.1:161 --data-dir=.\tests 
+start "The SNMP Emulator" %~dp0..\..\..\..\..\Python3\Scripts\snmpsim-command-responder --agent-udpv4-endpoint=127.0.0.1:161 --data-dir=%~dp0tests 


### PR DESCRIPTION
The following [failure](https://epics-jenkins.isis.rl.ac.uk/job/System_Tests/6642/testReport/junit/(root)/ReportFailLoadTestsuiteTestCase/lndyisw_module_failed_to_load/) is probably coming because of not resolving the path of the emulator from the path where the test execution is rooted. Added the variable to stick the absolute path for correct resolution.